### PR TITLE
Properly handle ERANGE in parse_uid on 32-bit platforms

### DIFF
--- a/src/shared/user-util.c
+++ b/src/shared/user-util.c
@@ -59,7 +59,7 @@ int parse_uid(const char *s, uid_t *ret) {
                 unsigned long v = strtoul(s, &end, 10);
                 if (!end || *end)
                         r = -EINVAL;
-                else if (v > UINT_MAX)
+                else if (errno == ERANGE || v > UINT_MAX)
                         r = -ERANGE;
                 else
                         uid = v;


### PR DESCRIPTION
On 32-bit platforms, `errno` is set to `ERANGE` if the input value is not representable as a 32-bit unsigned integer, which should be the proper condition for returning `-ERANGE` here.

Fixes #1 